### PR TITLE
feat: add RC_BILLING store type and make period_type optional

### DIFF
--- a/period_type_value.go
+++ b/period_type_value.go
@@ -1,7 +1,6 @@
 package revcatgo
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -45,15 +44,18 @@ func (p periodType) MarshalJSON() ([]byte, error) {
 	return p.value.MarshalJSON()
 }
 
-// UnmarshalJSON deserializes a store from JSON
+// UnmarshalJSON deserializes a period type from JSON.
+// period_type is optional - it's only present in subscription lifecycle events,
+// not in events like TEST or EXPERIMENT_ENROLLMENT.
 func (p *periodType) UnmarshalJSON(b []byte) error {
 	v := &periodType{}
 	err := v.value.UnmarshalJSON(b)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal the value of period_type: %w", err)
 	}
+	// period_type is optional - allow null/missing values
 	if !v.value.Valid {
-		return errors.New("period_type is a required field")
+		return nil
 	}
 	_p, err := newPeriodType(strings.ToUpper(v.value.ValueOrZero()))
 	if err != nil {

--- a/period_type_value_test.go
+++ b/period_type_value_test.go
@@ -40,7 +40,7 @@ func TestPeriodTypeUnMarshal(t *testing.T) {
 		{`"NORMAL"`, "NORMAL", nil},
 		{`"INVALID"`, "", errors.New("")},
 		{`1`, "", errors.New("")},
-		{`null`, "", errors.New("")},
+		{`null`, "", nil}, // null is valid - period_type is optional for non-subscription events
 	}
 
 	for _, c := range cases {

--- a/store_value.go
+++ b/store_value.go
@@ -25,6 +25,8 @@ const (
 	StoreMacAppStore = "MAC_APP_STORE"
 	// StorePromotional identifies purchases granted via promotional credits.
 	StorePromotional = "PROMOTIONAL"
+	// StoreRCBilling identifies purchases processed through RevenueCat Web Billing.
+	StoreRCBilling = "RC_BILLING"
 )
 
 var validStoreValues = []string{
@@ -33,6 +35,7 @@ var validStoreValues = []string{
 	StoreStripe,
 	StoreMacAppStore,
 	StorePromotional,
+	StoreRCBilling,
 }
 
 func newStore(s string) (*store, error) {

--- a/store_value_test.go
+++ b/store_value_test.go
@@ -16,7 +16,8 @@ func TestNewStore(t *testing.T) {
 	}{
 		{"PLAY_STORE", "PLAY_STORE", nil},
 		{"APP_STORE", "APP_STORE", nil},
-		{"INVALID", "", errors.New("store value should be one of the following: PLAY_STORE, APP_STORE, STRIPE, MAC_APP_STORE, PROMOTIONAL, got INVALID")},
+		{"RC_BILLING", "RC_BILLING", nil},
+		{"INVALID", "", errors.New("store value should be one of the following: PLAY_STORE, APP_STORE, STRIPE, MAC_APP_STORE, PROMOTIONAL, RC_BILLING, got INVALID")},
 	}
 
 	for _, c := range cases {
@@ -38,6 +39,7 @@ func TestStoreUnMarshal(t *testing.T) {
 	}{
 		{`"PLAY_STORE"`, "PLAY_STORE", nil},
 		{`"APP_STORE"`, "APP_STORE", nil},
+		{`"RC_BILLING"`, "RC_BILLING", nil},
 		{`"INVALID"`, "", errors.New("")},
 		{`1`, "", errors.New("")},
 		{`null`, "", errors.New("")},


### PR DESCRIPTION
## Summary

This PR adds support for RevenueCat Web Billing webhooks and fixes webhook parsing for non-subscription events.

## Changes

### 1. Add RC_BILLING store type
RevenueCat's Web Billing feature uses `RC_BILLING` as the store value in webhook payloads.

- Added `StoreRCBilling` constant with value `"RC_BILLING"`
- Added `RC_BILLING` to `validStoreValues` slice
- Added test cases for the new store type

### 2. Make period_type optional
RevenueCat only includes `period_type` in subscription lifecycle events. Non-subscription events like `TEST`, `EXPERIMENT_ENROLLMENT`, and others don't have this field.

- Changed `period_type` validation to allow null/missing values
- Updated test to expect null to succeed

## Reference

- [RevenueCat Web Billing documentation](https://www.revenuecat.com/docs/web/web-billing)
- [RevenueCat Webhook Event Types](https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields)

## Testing

All existing tests pass, and new/updated test cases have been added.