### PR TITLE
feat: add store_transaction_id mapping (webhook + subscriber)

### DIFF
--- a/event.go
+++ b/event.go
@@ -46,6 +46,7 @@ type Event struct {
 	Experiments              []experiment         `json:"experiments"`
 	TransactionID            string               `json:"transaction_id"`
 	OriginalTransactionID    string               `json:"original_transaction_id"`
+	StoreTransactionID       string               `json:"store_transaction_id"`
 	IsFamilyShare            bool                 `json:"is_family_share"`
 	TransferredFrom          []string             `json:"transferred_from"`
 	TransferredTo            []string             `json:"transferred_to"`

--- a/event_test.go
+++ b/event_test.go
@@ -79,6 +79,7 @@ const initialPurchaseRawJSON = `
    "store": "PLAY_STORE",
    "price": 5.233,
    "transaction_id": "GPA.0000-4204-5621-00000",
+   "store_transaction_id": "GPA.0000-4204-5621-00000",
    "period_type": "NORMAL",
    "id": "00A23FAE-0DB8-42E2-A8DC-00000BCDF0D6",
    "aliases": [
@@ -109,6 +110,7 @@ func TestUnmarshalInitialPurchaseEvent(t *testing.T) {
 	assert.Equal(t, float32(550), event.PriceInPurchasedCurrency)
 	assert.Equal(t, float32(5.5), event.TaxPercentage)
 	assert.Equal(t, "app-123", event.AppID)
+	assert.Equal(t, "GPA.0000-4204-5621-00000", event.StoreTransactionID)
 	assert.Len(t, event.Experiments, 1)
 	assert.Equal(t, "exp_a", event.Experiments[0].ID)
 	assert.Equal(t, int64(1605256730251), event.ExpirationAt.Int64())
@@ -134,6 +136,7 @@ const cancellationRawJSON = `
    "id": "00A23FAE-0DB8-42E2-A8DC-00000BCDF0D6",
    "environment": "SANDBOX",
    "transaction_id": "GPA.0000-4204-5621-00000",
+   "store_transaction_id": "GPA.0000-4204-5621-00000",
    "period_type": "NORMAL",
    "price_in_purchased_currency": 0,
    "subscriber_attributes": {
@@ -165,6 +168,7 @@ func TestUnmarshalCancellationEvent(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "BILLING_ERROR", event.CancelReason.String())
+	assert.Equal(t, "GPA.0000-4204-5621-00000", event.StoreTransactionID)
 }
 
 const virtualCurrencyTransactionJSON = `

--- a/store_transaction_id_value.go
+++ b/store_transaction_id_value.go
@@ -1,0 +1,40 @@
+package revcatgo
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// storeTransactionID represents the store_transaction_id field returned by the
+// RevenueCat REST API. The App Store reports it as a JSON number while the
+// other stores report it as a JSON string, so the value is normalized to a
+// string.
+type storeTransactionID struct {
+	value null.String
+}
+
+// String returns the store transaction id.
+func (s *storeTransactionID) String() string {
+	return s.value.ValueOrZero()
+}
+
+func (s storeTransactionID) MarshalJSON() ([]byte, error) {
+	return s.value.MarshalJSON()
+}
+
+// UnmarshalJSON deserializes a store transaction id from either a JSON string
+// or a JSON number.
+func (s *storeTransactionID) UnmarshalJSON(b []byte) error {
+	// Numbers are reported unquoted (e.g. by the App Store); quote them so the
+	// raw token is preserved exactly and parsed as a string.
+	if len(b) > 0 && b[0] != '"' && !bytes.Equal(b, []byte("null")) {
+		b = append([]byte{'"'}, append(b, '"')...)
+	}
+	if err := s.value.UnmarshalJSON(b); err != nil {
+		return fmt.Errorf("failed to unmarshal the value of store transaction id: %w", err)
+	}
+
+	return nil
+}

--- a/store_transaction_id_value.go
+++ b/store_transaction_id_value.go
@@ -28,9 +28,15 @@ func (s storeTransactionID) MarshalJSON() ([]byte, error) {
 // or a JSON number.
 func (s *storeTransactionID) UnmarshalJSON(b []byte) error {
 	// Numbers are reported unquoted (e.g. by the App Store); quote them so the
-	// raw token is preserved exactly and parsed as a string.
+	// raw token is preserved exactly and parsed as a string. Build the quoted
+	// token in a fresh buffer: b may alias json.Unmarshal's backing array, so
+	// appending to it could overwrite the surrounding raw JSON.
 	if len(b) > 0 && b[0] != '"' && !bytes.Equal(b, []byte("null")) {
-		b = append([]byte{'"'}, append(b, '"')...)
+		quoted := make([]byte, 0, len(b)+2)
+		quoted = append(quoted, '"')
+		quoted = append(quoted, b...)
+		quoted = append(quoted, '"')
+		b = quoted
 	}
 	if err := s.value.UnmarshalJSON(b); err != nil {
 		return fmt.Errorf("failed to unmarshal the value of store transaction id: %w", err)

--- a/store_transaction_id_value_test.go
+++ b/store_transaction_id_value_test.go
@@ -25,3 +25,23 @@ func TestStoreTransactionIDUnMarshal(t *testing.T) {
 		assert.Equal(t, c.expected, s.String())
 	}
 }
+
+// TestStoreTransactionIDPreservesRawInput guards against mutating the raw JSON
+// buffer while quoting a numeric id, which would corrupt the bytes following
+// the token for callers that retain the original response.
+func TestStoreTransactionIDPreservesRawInput(t *testing.T) {
+	type payload struct {
+		ID        storeTransactionID `json:"store_transaction_id"`
+		IsSandbox bool               `json:"is_sandbox"`
+	}
+
+	raw := []byte(`{"store_transaction_id":1000000652379790,"is_sandbox":true}`)
+	original := string(raw)
+
+	var p payload
+	err := json.Unmarshal(raw, &p)
+	assert.Nil(t, err)
+	assert.Equal(t, "1000000652379790", p.ID.String())
+	assert.True(t, p.IsSandbox)
+	assert.Equal(t, original, string(raw))
+}

--- a/store_transaction_id_value_test.go
+++ b/store_transaction_id_value_test.go
@@ -1,0 +1,27 @@
+package revcatgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreTransactionIDUnMarshal(t *testing.T) {
+	cases := []struct {
+		in       string
+		expected string
+	}{
+		{`"GPA.6801-7988-0152-76034..5"`, "GPA.6801-7988-0152-76034..5"},
+		{`1000000652379790`, "1000000652379790"},
+		{`"a42db3af39530cb82b17eaf9c6576393"`, "a42db3af39530cb82b17eaf9c6576393"},
+		{`null`, ""},
+	}
+
+	for _, c := range cases {
+		var s storeTransactionID
+		err := json.Unmarshal([]byte(c.in), &s)
+		assert.Nil(t, err)
+		assert.Equal(t, c.expected, s.String())
+	}
+}

--- a/subscriber.go
+++ b/subscriber.go
@@ -33,15 +33,16 @@ type Entitlement struct {
 
 // Subscription captures the state of an individual auto-renewing subscription.
 type Subscription struct {
-	ExpiresDate            time.Time  `json:"expires_date"`
-	GracePeriodExpiresDate null.Time  `json:"grace_period_expires_date"`
-	PurchaseDate           time.Time  `json:"purchase_date"`
-	OriginalPurchaseDate   time.Time  `json:"original_purchase_date"`
-	PeriodType             periodType `json:"period_type"`
-	Store                  store      `json:"store"`
-	IsSandBox              bool       `json:"is_sandbox"`
-	UnsubscribeDetectedAt  null.Time  `json:"unsubscribe_detected_at"`
-	BillingIssueDetectedAt null.Time  `json:"billing_issue_detected_at"`
+	ExpiresDate            time.Time          `json:"expires_date"`
+	GracePeriodExpiresDate null.Time          `json:"grace_period_expires_date"`
+	PurchaseDate           time.Time          `json:"purchase_date"`
+	OriginalPurchaseDate   time.Time          `json:"original_purchase_date"`
+	PeriodType             periodType         `json:"period_type"`
+	Store                  store              `json:"store"`
+	StoreTransactionID     storeTransactionID `json:"store_transaction_id"`
+	IsSandBox              bool               `json:"is_sandbox"`
+	UnsubscribeDetectedAt  null.Time          `json:"unsubscribe_detected_at"`
+	BillingIssueDetectedAt null.Time          `json:"billing_issue_detected_at"`
 }
 
 // NonSubscription describes a one-off, non-renewing purchase.

--- a/subscriber.go
+++ b/subscriber.go
@@ -47,8 +47,9 @@ type Subscription struct {
 
 // NonSubscription describes a one-off, non-renewing purchase.
 type NonSubscription struct {
-	ID           string    `json:"id"`
-	Store        store     `json:"store"`
-	PurchaseDate time.Time `json:"purchase_date"`
-	IsSandBox    bool      `json:"is_sandbox"`
+	ID                 string             `json:"id"`
+	Store              store              `json:"store"`
+	StoreTransactionID storeTransactionID `json:"store_transaction_id"`
+	PurchaseDate       time.Time          `json:"purchase_date"`
+	IsSandBox          bool               `json:"is_sandbox"`
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -1,0 +1,58 @@
+package revcatgo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// subscriberRawJSON is trimmed from a RevenueCat v1 GET /subscribers response.
+// It keeps one Play Store subscription (string store_transaction_id) and one
+// App Store subscription (numeric store_transaction_id) to cover both shapes.
+const subscriberRawJSON = `
+{
+  "request_date_ms": 1564162810884,
+  "subscriber": {
+    "entitlements": {},
+    "first_seen": "2019-02-21T00:08:41Z",
+    "last_seen": "2019-07-26T17:40:10Z",
+    "original_app_user_id": "XXX-XXXXX-XXXXX-XX",
+    "non_subscriptions": {},
+    "subscriptions": {
+      "annual": {
+        "expires_date": "2019-08-14T21:07:40Z",
+        "original_purchase_date": "2019-02-21T00:42:05Z",
+        "period_type": "normal",
+        "purchase_date": "2019-07-14T20:07:40Z",
+        "store": "play_store",
+        "store_transaction_id": "GPA.6801-7988-0152-76034..5",
+        "is_sandbox": true
+      },
+      "onemonth": {
+        "expires_date": "2019-06-17T22:47:55Z",
+        "original_purchase_date": "2019-02-21T00:42:05Z",
+        "period_type": "normal",
+        "purchase_date": "2019-06-17T22:42:55Z",
+        "store": "app_store",
+        "store_transaction_id": 1000000652379790,
+        "is_sandbox": true
+      }
+    }
+  }
+}
+`
+
+func TestUnmarshalSubscriberResponse(t *testing.T) {
+	var resp SubscriberResponse
+	err := json.Unmarshal([]byte(subscriberRawJSON), &resp)
+	assert.Nil(t, err)
+
+	annual := resp.Subscriber.Subscriptions["annual"]
+	assert.Equal(t, "PLAY_STORE", annual.Store.String())
+	assert.Equal(t, "GPA.6801-7988-0152-76034..5", annual.StoreTransactionID.String())
+
+	onemonth := resp.Subscriber.Subscriptions["onemonth"]
+	assert.Equal(t, "APP_STORE", onemonth.Store.String())
+	assert.Equal(t, "1000000652379790", onemonth.StoreTransactionID.String())
+}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -18,7 +18,17 @@ const subscriberRawJSON = `
     "first_seen": "2019-02-21T00:08:41Z",
     "last_seen": "2019-07-26T17:40:10Z",
     "original_app_user_id": "XXX-XXXXX-XXXXX-XX",
-    "non_subscriptions": {},
+    "non_subscriptions": {
+      "coins": [
+        {
+          "id": "cadba0c81b",
+          "store": "app_store",
+          "store_transaction_id": 1000000652379790,
+          "purchase_date": "2019-04-05T21:52:45Z",
+          "is_sandbox": true
+        }
+      ]
+    },
     "subscriptions": {
       "annual": {
         "expires_date": "2019-08-14T21:07:40Z",
@@ -55,4 +65,9 @@ func TestUnmarshalSubscriberResponse(t *testing.T) {
 	onemonth := resp.Subscriber.Subscriptions["onemonth"]
 	assert.Equal(t, "APP_STORE", onemonth.Store.String())
 	assert.Equal(t, "1000000652379790", onemonth.StoreTransactionID.String())
+
+	coins := resp.Subscriber.NonSubscription["coins"]
+	assert.Len(t, coins, 1)
+	assert.Equal(t, "APP_STORE", coins[0].Store.String())
+	assert.Equal(t, "1000000652379790", coins[0].StoreTransactionID.String())
 }


### PR DESCRIPTION
## What

Maps the `store_transaction_id` field everywhere the RevenueCat API reports it:

- `Event` (webhook payload)
- `Subscription` (the `subscriptions` object in the v1 `GET /subscribers` response)

## Why

RevenueCat documents `store_transaction_id` as the store's own transaction identifier ("orderId or transaction_identifier"). It sits next to the already-mapped `transaction_id` / `original_transaction_id`, but the library dropped it on unmarshal, so callers had no way to read it.

The field matters for a common pattern: storing webhook events and later reconciling them against transactions fetched from the REST API (for example, to dedupe transactions a backend has already processed). That reconciliation needs a key that is present and identical on both sides, and `store_transaction_id` is the one that fits:

- The webhook event exposes `store_transaction_id` (the store ID) and `transaction_id` (RevenueCat's reference).
- The REST transactions endpoint returns each transaction with both an `id` (RevenueCat's own, in `txn_...` form) and a `store_transaction_id` ("The transaction ID from the store").

The two surfaces do not share a value space for the RevenueCat-native identifier: the webhook's `transaction_id` carries the store value, while the REST `id` is a `txn_...` handle. The field that holds the same store-issued value in both places is `store_transaction_id`. RevenueCat's own v2 lookup endpoints reflect this by searching on `store_purchase_identifier` / `store_subscription_identifier`.

It is also the right granularity for transaction-level dedupe: each renewal or purchase gets its own `store_transaction_id` (Apple issues a new `transaction_identifier`; Google appends a suffix to the order ID), whereas `original_store_transaction_id` stays constant across a subscription.

## The number-vs-string detail

The v1 `GET /subscribers` response reports `store_transaction_id` differently per store:

```json
"store": "play_store",
"store_transaction_id": "GPA.6801-7988-0152-76034..5"
```
```json
"store": "app_store",
"store_transaction_id": 1000000652379790
```

The App Store value arrives as a JSON number, the others as strings. A plain `string` field fails to unmarshal the numeric case, so this adds a small `storeTransactionID` value type (in the same style as the existing `store` / `price` types) that accepts either shape and normalizes to a string via `String()`. The webhook field stays a plain `string`, since webhooks always quote the value.

`non_subscriptions` and `entitlements` do not carry the field, so they are left untouched.

## Changes

- `event.go`: add `StoreTransactionID` to `Event`.
- `subscriber.go`: add `StoreTransactionID` to `Subscription`.
- `store_transaction_id_value.go`: `storeTransactionID` value type handling string-or-number input.
- Tests: assert the field in the initial-purchase and cancellation webhook fixtures, a value-type test covering string/number/null, and a `GET /subscribers` unmarshal test covering both store shapes.

## Verification

`make fmt`, `make lint` (0 issues) and `make test` all pass (25 tests).
